### PR TITLE
fix bug: without corresponding makecurrent()

### DIFF
--- a/src/osgQt/GraphicsWindowQt.cpp
+++ b/src/osgQt/GraphicsWindowQt.cpp
@@ -286,7 +286,7 @@ void GLWidget::setKeyboardModifiers( QInputEvent* event )
 void GLWidget::resizeEvent( QResizeEvent* event )
 {
     if (_gw == NULL || !_gw->valid())
-		return;    
+	return;    
     const QSize& size = event->size();
     int scaled_width = static_cast<int>(size.width()*_devicePixelRatio);
     int scaled_height = static_cast<int>(size.height()*_devicePixelRatio);
@@ -298,7 +298,7 @@ void GLWidget::resizeEvent( QResizeEvent* event )
 void GLWidget::moveEvent( QMoveEvent* event )
 {
     if (_gw == NULL || !_gw->valid())
-		return; 
+	return; 
     const QPoint& pos = event->pos();
     int scaled_width = static_cast<int>(width()*_devicePixelRatio);
     int scaled_height = static_cast<int>(height()*_devicePixelRatio);
@@ -851,8 +851,6 @@ bool GraphicsWindowQt::releaseContextImplementation()
 
 void GraphicsWindowQt::swapBuffersImplementation()
 {
-    _widget->swapBuffers();
-
     // FIXME: the processDeferredEvents should really be executed in a GUI (main) thread context but
     // I couln't find any reliable way to do this. For now, lets hope non of *GUI thread only operations* will
     // be executed in a QGLWidget::event handler. On the other hand, calling GUI only operations in the
@@ -862,8 +860,8 @@ void GraphicsWindowQt::swapBuffersImplementation()
 
     // We need to call makeCurrent here to restore our previously current context
     // which may be changed by the processDeferredEvents function.
-    if (QGLContext::currentContext() != _widget->context())
-        _widget->makeCurrent();
+    _widget->makeCurrent();
+    _widget->swapBuffers();
 }
 
 void GraphicsWindowQt::requestWarpPointer( float x, float y )


### PR DESCRIPTION
If I hadn't call makeCurrent function before swapBuffers by using ThreadingModel::CullThreadPerCameraDrawThreadPerContext with Qt5.9, I will get this warning: qopenglcontext::swapbuffers() called without corresponding makecurrent().