### PR TITLE
Added missing Camera::setDrawBuffer()/setReadBuffer()

### DIFF
--- a/examples/osgqfont/osgqfont.cpp
+++ b/examples/osgqfont/osgqfont.cpp
@@ -503,6 +503,10 @@ public:
         camera->setGraphicsContext(graphicsWindow);
         camera->setViewport(new osg::Viewport(0, 0, width(), height()));
 
+        // set the draw and read buffers up for a double buffered window with rendering going to back buffer
+        camera->setDrawBuffer(GL_BACK);
+        camera->setReadBuffer(GL_BACK);
+
         startTimer(10);
     }
 

--- a/examples/osgviewerQt/osgviewerQt.cpp
+++ b/examples/osgviewerQt/osgviewerQt.cpp
@@ -53,6 +53,11 @@ public:
 
         camera->setClearColor( osg::Vec4(0.2, 0.2, 0.6, 1.0) );
         camera->setViewport( new osg::Viewport(0, 0, traits->width, traits->height) );
+
+        // set the draw and read buffers up for a double buffered window with rendering going to back buffer
+        camera->setDrawBuffer(GL_BACK);
+        camera->setReadBuffer(GL_BACK);
+
         camera->setProjectionMatrixAsPerspective(30.0f, static_cast<double>(traits->width)/static_cast<double>(traits->height), 1.0f, 10000.0f );
 
         view->setSceneData( scene );


### PR DESCRIPTION
Added missing Camera::setDrawBuffer(..) and setReadBuffer() calls.  

These calls address the ambiguity that happens when GL defaults are left in place, something that can cause problems when handling RTT setups.