### PR TITLE
Compile errors on Visual Studio 

### DIFF
--- a/include/osgQOpenGL/osgQOpenGLWidget
+++ b/include/osgQOpenGL/osgQOpenGLWidget
@@ -39,6 +39,7 @@ protected:
     bool _osgWantsToRenderFrame{true};
     OpenThreads::ReadWriteMutex _osgMutex;
     osg::ArgumentParser* _arguments {nullptr};
+	bool _isFirstFrame {true};
 
     friend class OSGRenderer;
 

--- a/include/osgQOpenGL/osgQOpenGLWidget
+++ b/include/osgQOpenGL/osgQOpenGLWidget
@@ -12,7 +12,7 @@
 #include <OpenThreads/ReadWriteMutex>
 
 #ifdef WIN32
-#define __gl_h_
+//#define __gl_h_
 #include <osg/GL>
 #endif
 

--- a/include/osgQOpenGL/osgQOpenGLWindow
+++ b/include/osgQOpenGL/osgQOpenGLWindow
@@ -37,7 +37,7 @@ protected:
     OSGRenderer* m_renderer {nullptr};
     bool _osgWantsToRenderFrame{true};
     OpenThreads::ReadWriteMutex _osgMutex;
-
+	bool _isFirstFrame {true};
     friend class OSGRenderer;
 
     QWidget* _widget = nullptr;

--- a/include/osgQOpenGL/osgQOpenGLWindow
+++ b/include/osgQOpenGL/osgQOpenGLWindow
@@ -12,7 +12,7 @@
 #include <OpenThreads/ReadWriteMutex>
 
 #ifdef WIN32
-#define __gl_h_
+//#define __gl_h_
 #include <osg/GL>
 #endif
 

--- a/src/osgQOpenGL/OSGRenderer.cpp
+++ b/src/osgQOpenGL/OSGRenderer.cpp
@@ -206,15 +206,6 @@ void OSGRenderer::setupOSG(int windowWidth, int windowHeight, float windowScale)
     osgViewer::Viewer::Windows windows;
     getWindows(windows);
 
-    for(osgViewer::Viewer::Windows::iterator itr = windows.begin();
-        itr != windows.end(); ++itr)
-    {
-        (*itr)->getState()->setUseModelViewAndProjectionUniforms(true);
-        (*itr)->getState()->setUseVertexAttributeAliasing(true);
-        (*itr)->getState()->setShaderCompositionEnabled(
-            false); // TODO: check if we need it ???
-    }
-
     _timerId = startTimer(10, Qt::PreciseTimer);
     _lastFrameStartTime.setStartTick(0);
 }

--- a/src/osgQOpenGL/osgQOpenGLWidget.cpp
+++ b/src/osgQOpenGL/osgQOpenGLWidget.cpp
@@ -60,7 +60,11 @@ void osgQOpenGLWidget::resizeGL(int w, int h)
 void osgQOpenGLWidget::paintGL()
 {
     OpenThreads::ScopedReadLock locker(_osgMutex);
-    m_renderer->frame();
+	if (_isFirstFrame) {
+		_isFirstFrame = false;
+		m_renderer->getCamera()->getGraphicsContext()->setDefaultFboId(defaultFramebufferObject());
+	}
+	m_renderer->frame();
 }
 
 void osgQOpenGLWidget::keyPressEvent(QKeyEvent* event)

--- a/src/osgQOpenGL/osgQOpenGLWidget.cpp
+++ b/src/osgQOpenGL/osgQOpenGLWidget.cpp
@@ -205,9 +205,12 @@ void osgQOpenGLWidget::createRenderer()
 {
     // call this before creating a View...
     setDefaultDisplaySettings();
-
-    m_renderer = new OSGRenderer(_arguments, this);
-    QScreen* screen = windowHandle()
+	if (!_arguments) {
+		m_renderer = new OSGRenderer(this);
+	} else {
+		m_renderer = new OSGRenderer(_arguments, this);
+	}
+	QScreen* screen = windowHandle()
                       && windowHandle()->screen() ? windowHandle()->screen() :
                       qApp->screens().front();
     m_renderer->setupOSG(width(), height(), screen->devicePixelRatio());

--- a/src/osgQOpenGL/osgQOpenGLWindow.cpp
+++ b/src/osgQOpenGL/osgQOpenGLWindow.cpp
@@ -52,6 +52,10 @@ void osgQOpenGLWindow::resizeGL(int w, int h)
 void osgQOpenGLWindow::paintGL()
 {
     OpenThreads::ScopedReadLock locker(_osgMutex);
+	if (_isFirstFrame) {
+		_isFirstFrame = false;
+		m_renderer->getCamera()->getGraphicsContext()->setDefaultFboId(defaultFramebufferObject());
+	}
     m_renderer->frame();
 }
 


### PR DESCRIPTION
When compiling on Visual Studio 2013 (and others most likely that use WIN32) the Gl.h file is not compiled properly due the definition of __gl_h_ before including osg/Gl leading to compile erros on Glfloat etc.
See also http://forum.openscenegraph.org/viewtopic.php?t=17842