### PR TITLE
override sizeHint in osgQOpenGLWidget

### DIFF
--- a/include/osgQOpenGL/osgQOpenGLWidget
+++ b/include/osgQOpenGL/osgQOpenGLWidget
@@ -53,7 +53,10 @@ public:
 
     //! get mutex
     virtual OpenThreads::ReadWriteMutex* mutex();
-
+    
+    //! override this to change default size or aspect ratio 
+    QSize sizeHint() const override { return QSize(640,480); }
+    
 signals:
     void initialized();
 


### PR DESCRIPTION
Default value of QWidget::rect is 0,0,640,480. This SD aspect ratio agrees with OSG when widget is shown by itself. However, once widget is put into a layout it has to return a valid sizeHint in order to preserve this aspect ratio and size.  
https://doc.qt.io/qt-5/qwidget.html#size-hints-and-size-policies  
