### PR TITLE
export target osg-qt::osgQOpenGL to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ ENDIF()
 
 PROJECT(osgQt)
 
+INCLUDE(GNUInstallDirs)
 FIND_PACKAGE(OpenSceneGraph 3.6.0 REQUIRED osgDB osgGA osgUtil osgText osgViewer osgWidget)
 SET(OPENSCENEGRAPH_SOVERSION 145)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.0.0 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.15 FATAL_ERROR)
 
 IF(APPLE)
   # Get OSX version in MAJOR.MINOR format
@@ -926,3 +926,35 @@ ADD_CUSTOM_TARGET(uninstall
 
 #
 
+add_library(osg-qt ALIAS osgQOpenGL)
+add_library(osgqt ALIAS osgQOpenGL)
+
+install(TARGETS osgQOpenGL
+    EXPORT osgQOpenGL-targets
+)
+
+install(EXPORT osgQOpenGL-targets
+    FILE osg-qtTargets.cmake  
+    NAMESPACE osg-qt::
+    DESTINATION "share/cmake/osg-qt"
+)
+
+include(CMakePackageConfigHelpers)  # 引入模块 [3,5](@ref)
+
+configure_package_config_file(
+    "osgQOpenGLConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/osg-qtConfig.cmake"
+    INSTALL_DESTINATION "share/cmake/osg-qt"
+)
+
+write_basic_package_version_file(
+    "osg-qtConfigVersion.cmake"
+    VERSION 1.0.0
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/osg-qtConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/osg-qtConfigVersion.cmake"
+    DESTINATION "share/cmake/osg-qt"
+)

--- a/osgQOpenGLConfig.cmake.in
+++ b/osgQOpenGLConfig.cmake.in
@@ -1,0 +1,2 @@
+include(CMakeFindDependencyMacro)
+include("${CMAKE_CURRENT_LIST_DIR}/osg-qtTargets.cmake") 

--- a/osgQOpenGLConfig.cmake.in
+++ b/osgQOpenGLConfig.cmake.in
@@ -4,9 +4,7 @@ endif()
 
 include(CMakeFindDependencyMacro)
 
-if(NOT TARGET Qt5::OpenGL)
-    find_dependency(Qt5 COMPONENTS Gui OpenGL REQUIRED)
-endif()
+find_dependency(Qt5 COMPONENTS Widgets OpenGL)
 # Instead of checking OPENSCENEGRAPH_LIBRARIES, check osgViewer and osgUtil specifically
 if(NOT DEFINED OSGUTIL_LIBRARIES OR NOT DEFINED OSGVIEWER_LIBRARIES OR NOT DEFINED OPENSCENEGRAPH_INCLUDE_DIRS)
     find_dependency(OpenSceneGraph COMPONENTS osgUtil osgViewer)

--- a/osgQOpenGLConfig.cmake.in
+++ b/osgQOpenGLConfig.cmake.in
@@ -1,2 +1,24 @@
+if(TARGET osg-qt::osgQOpenGL)
+    set(_OSGQOPENGL_ALREADY_DEFINED ON)
+endif()
+
 include(CMakeFindDependencyMacro)
-include("${CMAKE_CURRENT_LIST_DIR}/osg-qtTargets.cmake") 
+
+if(NOT TARGET Qt5::OpenGL)
+    find_dependency(Qt5 COMPONENTS Gui OpenGL REQUIRED)
+endif()
+# Instead of checking OPENSCENEGRAPH_LIBRARIES, check osgViewer and osgUtil specifically
+if(NOT DEFINED OSGUTIL_LIBRARIES OR NOT DEFINED OSGVIEWER_LIBRARIES OR NOT DEFINED OPENSCENEGRAPH_INCLUDE_DIRS)
+    find_dependency(OpenSceneGraph COMPONENTS osgUtil osgViewer REQUIRED)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/osg-qtTargets.cmake")
+
+if(NOT _OSGQOPENGL_ALREADY_DEFINED)
+    # Replace the interface link libraries with those found by OSG, to allow this to be more easily relocatable.
+    # Without this, absolute paths to OSG are stored in the target, making the output library non-relocatable
+    # to other machines unless they have OSG in the exact same location.
+    set_target_properties(osg-qt::osgQOpenGL PROPERTIES INTERFACE_LINK_LIBRARIES "Qt5::Widgets;Qt5::OpenGL")
+    target_link_libraries(osg-qt::osgQOpenGL INTERFACE ${OPENSCENEGRAPH_LIBRARIES})
+    target_include_directories(osg-qt::osgQOpenGL INTERFACE ${OPENSCENEGRAPH_INCLUDE_DIRS})
+endif()

--- a/osgQOpenGLConfig.cmake.in
+++ b/osgQOpenGLConfig.cmake.in
@@ -9,7 +9,7 @@ if(NOT TARGET Qt5::OpenGL)
 endif()
 # Instead of checking OPENSCENEGRAPH_LIBRARIES, check osgViewer and osgUtil specifically
 if(NOT DEFINED OSGUTIL_LIBRARIES OR NOT DEFINED OSGVIEWER_LIBRARIES OR NOT DEFINED OPENSCENEGRAPH_INCLUDE_DIRS)
-    find_dependency(OpenSceneGraph COMPONENTS osgUtil osgViewer REQUIRED)
+    find_dependency(OpenSceneGraph COMPONENTS osgUtil osgViewer)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/osg-qtTargets.cmake")

--- a/src/osgQOpenGL/CMakeLists.txt
+++ b/src/osgQOpenGL/CMakeLists.txt
@@ -50,6 +50,7 @@ IF ( Qt5Widgets_FOUND )
 
     SETUP_LIBRARY(${LIB_NAME})
 
+    target_include_directories(${LIB_NAME} PUBLIC $<INSTALL_INTERFACE:include>)
     generate_export_header(${LIB_NAME} EXPORT_FILE_NAME "Export")
 
 ENDIF()

--- a/usage
+++ b/usage
@@ -1,0 +1,4 @@
+osg-qt provides CMake targets:
+
+    find_package(osg-qt REQUIRED)
+    target_link_libraries(main PRIVATE osg-qt::osgQOpenGL)


### PR DESCRIPTION
https://github.com/microsoft/vcpkg/issues/44441
https://github.com/openscenegraph/osgQt/issues/53
https://github.com/openscenegraph/osgQt/issues/57
https://github.com/microsoft/vcpkg/issues/26312

so many want to use osg-qt in the cmake way,
so may be we should export target osg-qt::osgQOpenGL to cmake